### PR TITLE
make run-experiments.sh more generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tensorflow-repo-prefix
 Testing/
 venv
 ansible_hosts.txt
+experiment-results.txt


### PR DESCRIPTION
example usage:

`x.sh`


```bash
#!/bin/sh
set -e
cd $(dirname $0)
export RUNNER=$USER
export SRC_DIR=$(pwd)
export EXPERIMENT_SCRIPT=./examples/mnist_mlp.py
# export EXPERIMENT_ARGS="--batch-size=1"

./scripts/azure/relay-machine/run-experiments.sh init-remote
./scripts/azure/relay-machine/run-experiments.sh prepare
./scripts/azure/relay-machine/run-experiments.sh run
```