### PR TITLE
fix reward function

### DIFF
--- a/experiments/kungfu/atari_pingpong/base_agent.py
+++ b/experiments/kungfu/atari_pingpong/base_agent.py
@@ -16,7 +16,7 @@ def normalize(x):
     return x
 
 
-def cumulative_discounted_reward(rewards, gamma=0.99):
+def cumulative_discounted_reward(rewards, gamma):
     cdr = []
     c = 0
     for r in rewards:
@@ -25,7 +25,13 @@ def cumulative_discounted_reward(rewards, gamma=0.99):
         else:
             c = c * gamma + r
         cdr.append(c)
-    return normalize(cdr)
+    return cdr
+
+
+def discount_episode_rewards(rewards):
+    gamma = 0.99
+    cdr = cumulative_discounted_reward(reversed(rewards), gamma)
+    return normalize(list(reversed(cdr)))
 
 
 class BaseAgent(object):
@@ -124,13 +130,12 @@ class BaseAgent(object):
             train_op,
         ) = self._model_ops
 
-        gamma = 0.99
         self.sess.run(
             train_op,
             feed_dict={
                 images: self.xs,
                 actions: self.ys,
-                discount_rewards: cumulative_discounted_reward(self.rs, gamma),
+                discount_rewards: discount_episode_rewards(self.rs),
             })
 
         self.xs = []


### PR DESCRIPTION

[adam-20h.log.gz](https://github.com/lsds/KungFu/files/2875521/adam-20h.log.gz)


```
[127.0.0.1/06/06-of-20::stdout] episode: 2061 end in 4571 steps, took  11.30s (  2.47ms/step), reward:    12.00; all took 41365.13s; 0.9-running reward: 11.21   , 0.99-running reward: 10.74   , 0.999-running reward: 3.75    
[127.0.0.1/14/14-of-20::stdout] episode: 2061 end in 4824 steps, took  12.15s (  2.52ms/step), reward:    14.00; all took 41365.67s; 0.9-running reward: 11.33   , 0.99-running reward: 10.82   , 0.999-running reward: 3.69    
[127.0.0.1/00/00-of-20::stdout] episode: 2061 end in 5169 steps, took  12.80s (  2.48ms/step), reward:    13.00; all took 41366.41s; 0.9-running reward: 11.84   , 0.99-running reward: 10.95   , 0.999-running reward: 3.72    
[127.0.0.1/17/17-of-20::stdout] episode: 2061 end in 5333 steps, took  13.42s (  2.52ms/step), reward:    12.00; all took 41367.08s; 0.9-running reward: 10.59   , 0.99-running reward: 10.87   , 0.999-running reward: 3.71    
[127.0.0.1/04/04-of-20::stdout] episode: 2061 end in 4627 steps, took  13.59s (  2.94ms/step), reward:    14.00; all took 41367.22s; 0.9-running reward: 11.29   , 0.99-running reward: 10.75   , 0.999-running reward: 3.69    
[127.0.0.1/12/12-of-20::stdout] episode: 2061 end in 5720 steps, took  13.78s (  2.41ms/step), reward:    13.00; all took 41367.68s; 0.9-running reward: 10.23   , 0.99-running reward: 10.96   , 0.999-running reward: 3.65    
[127.0.0.1/11/11-of-20::stdout] episode: 2061 end in 5521 steps, took  13.81s (  2.50ms/step), reward:    14.00; all took 41367.61s; 0.9-running reward: 10.69   , 0.99-running reward: 10.52   , 0.999-running reward: 3.66    
[127.0.0.1/08/08-of-20::stdout] episode: 2061 end in 5610 steps, took  13.98s (  2.49ms/step), reward:    11.00; all took 41367.81s; 0.9-running reward: 9.90    , 0.99-running reward: 10.59   , 0.999-running reward: 3.66    
[127.0.0.1/10/10-of-20::stdout] episode: 2061 end in 5970 steps, took  14.94s (  2.50ms/step), reward:     9.00; all took 41368.42s; 0.9-running reward: 9.98    , 0.99-running reward: 10.90   , 0.999-running reward: 3.83    
[127.0.0.1/13/13-of-20::stdout] episode: 2061 end in 6095 steps, took  15.01s (  2.46ms/step), reward:    12.00; all took 41368.60s; 0.9-running reward: 10.58   , 0.99-running reward: 10.50   , 0.999-running reward: 3.70    
[127.0.0.1/01/01-of-20::stdout] episode: 2061 end in 5591 steps, took  15.16s (  2.71ms/step), reward:    13.00; all took 41369.03s; 0.9-running reward: 10.52   , 0.99-running reward: 10.75   , 0.999-running reward: 3.77    
[127.0.0.1/03/03-of-20::stdout] episode: 2061 end in 6286 steps, took  15.62s (  2.49ms/step), reward:    14.00; all took 41369.21s; 0.9-running reward: 10.07   , 0.99-running reward: 10.66   , 0.999-running reward: 3.68    
[127.0.0.1/05/05-of-20::stdout] episode: 2061 end in 6087 steps, took  16.24s (  2.67ms/step), reward:     7.00; all took 41370.03s; 0.9-running reward: 10.14   , 0.99-running reward: 10.78   , 0.999-running reward: 3.69    
[127.0.0.1/16/16-of-20::stdout] episode: 2061 end in 6784 steps, took  16.69s (  2.46ms/step), reward:     9.00; all took 41370.56s; 0.9-running reward: 10.08   , 0.99-running reward: 10.82   , 0.999-running reward: 3.65    
[127.0.0.1/07/07-of-20::stdout] episode: 2061 end in 6542 steps, took  16.68s (  2.55ms/step), reward:    16.00; all took 41370.25s; 0.9-running reward: 11.92   , 0.99-running reward: 10.99   , 0.999-running reward: 3.86    
[127.0.0.1/18/18-of-20::stdout] episode: 2061 end in 7314 steps, took  17.63s (  2.41ms/step), reward:    12.00; all took 41371.48s; 0.9-running reward: 10.66   , 0.99-running reward: 10.73   , 0.999-running reward: 3.73    
[127.0.0.1/15/15-of-20::stdout] episode: 2061 end in 6399 steps, took  17.75s (  2.77ms/step), reward:     6.00; all took 41371.70s; 0.9-running reward: 9.69    , 0.99-running reward: 10.75   , 0.999-running reward: 3.64    
[127.0.0.1/19/19-of-20::stdout] episode: 2061 end in 7326 steps, took  18.18s (  2.48ms/step), reward:     7.00; all took 41372.05s; 0.9-running reward: 10.71   , 0.99-running reward: 11.13   , 0.999-running reward: 3.91    
[127.0.0.1/09/09-of-20::stdout] episode: 2061 end in 7972 steps, took  18.55s (  2.33ms/step), reward:    12.00; all took 41372.17s; 0.9-running reward: 12.74   , 0.99-running reward: 11.18   , 0.999-running reward: 3.70    
[127.0.0.1/02/02-of-20::stdout] episode: 2061 end in 8872 steps, took  20.60s (  2.32ms/step), reward:     2.00; all took 41374.29s; 0.9-running reward: 9.62    , 0.99-running reward: 10.72   , 0.999-running reward: 3.57    

```