### PR TITLE
fix benchmark

### DIFF
--- a/tests/go/fakemodel/fakemodel.go
+++ b/tests/go/fakemodel/fakemodel.go
@@ -2,6 +2,7 @@ package fakemodel
 
 import (
 	"fmt"
+	"sort"
 
 	kb "github.com/lsds/KungFu/srcs/go/kungfubase"
 	"github.com/lsds/KungFu/srcs/go/log"
@@ -19,6 +20,7 @@ var Names = func(m map[string][]int) []string {
 	for k := range m {
 		ks = append(ks, k)
 	}
+	sort.Strings(ks)
 	return ks
 }(Models)
 


### PR DESCRIPTION
regression.sh

```bash
#!/bin/sh
set -e

run_fake_go_trainer() {
    local np=$1
    local H=127.0.0.1:$np
    env \
        KUNGFU_TEST_CLUSTER_SIZE=$np \
        ./bin/kungfu-prun \
        -np=$np \
        -H $H \
        -timeout=120s \
        ./bin/fake-go-trainer \
        -model resnet50-imagenet 2>&1 | grep Img/sec
}

rebuild() {
    ./configure --build-tools --build-tests --with-mpi
    make -j 8

    CMAKE_SOURCE_DIR=$(pwd)
    export CGO_CFLAGS="-I${CMAKE_SOURCE_DIR}/srcs/cpp/include"
    export CGO_LDFLAGS="-L${CMAKE_SOURCE_DIR}/lib -lkungfu-base -lstdc++"
    env \
        GOBIN=$(pwd)/bin \
        go install -v ./tests/go/...
}

regression() {
    local KUNGFU_SRC=$1
    local commit=$2

    cd $KUNGFU_SRC
    git checkout -f $commit
    git clean -fdx

    rebuild 2>/dev/null >/dev/null

    run_fake_go_trainer 4
}

KUNGFU_SRC=$HOME/Desktop/kf-old

if [ ! -d $KUNGFU_SRC ]; then
    git clone git@github.com:lsds/KungFu.git $KUNGFU_SRC
fi

regression $KUNGFU_SRC c86f701cb096946b3d29e967094c324abc81d2b2 # Add benchmark for allreduce (#116)
regression $KUNGFU_SRC 6e1e8975003e47b162eb21037fdbf4358154685e # apply chunk optimization (#117)
```