### PR TITLE
Handling distributed variable initialization automatically.

### DIFF
--- a/benchmarks/system/benchmark_kungfu.py
+++ b/benchmarks/system/benchmark_kungfu.py
@@ -151,10 +151,6 @@ def run(benchmark_step):
 
 loss = loss_function()
 train_opt = opt.minimize(loss)
-if hasattr(opt, 'distributed_initializer'):
-    kf_init = opt.distributed_initializer()
-else:
-    kf_init = None
 
 if tf.executing_eagerly():
     with tf.device(device):
@@ -164,8 +160,6 @@ else:
     init = tf.global_variables_initializer()
     with tf.Session(config=config) as session:
         session.run(init)
-        if kf_init:
-            session.run(kf_init)
         run(lambda: session.run(train_opt))
         if barrier_op is not None:
             session.run(barrier_op)

--- a/examples/mnist_keras.py
+++ b/examples/mnist_keras.py
@@ -49,7 +49,7 @@ def build_optimizer(name, n_shards=1):
         return SynchronousSGDOptimizer(optimizer)
     elif name == 'async-sgd':
         from kungfu.tensorflow.v1.optimizers import PairAveragingOptimizer
-        return PairAveragingOptimizer(optimizer)
+        return PairAveragingOptimizer(optimizer, fuse_requests=True)
     elif name == 'sma':
         from kungfu.tensorflow.v1.optimizers import SynchronousAveragingOptimizer
         return SynchronousAveragingOptimizer(optimizer)

--- a/examples/mnist_slp.py
+++ b/examples/mnist_slp.py
@@ -148,11 +148,6 @@ def train_mnist(sess,
     offset = batch_size * shard_id
 
     sess.run(tf.global_variables_initializer())
-
-    # KUNGFU: KungFu initilizer defines how model weights are initilised on distributed devices
-    if hasattr(optimizer, 'distributed_initializer'):
-        sess.run(optimizer.distributed_initializer())
-
     print('training')
     # train the model with all batches allocated to the node
     for step in range(n_steps):

--- a/examples/mnist_slp.py
+++ b/examples/mnist_slp.py
@@ -2,13 +2,11 @@
 # This example shows how a MNIST Single Layer Perception Model training program
 # can adopt various distributed synchronization strategies using KungFu.
 #
-# In principle, KungFu requires users to make four changes:
+# In principle, KungFu requires users to make the following changes:
 # 1. KungFu provides distributed optimizers that can wrap the original optimizer.
 # The distributed optimizer defines how local gradients and model weights are synchronized.
-# 2. KungFu provides distributed variable initializers that defines how model weights are
-# initialized on distributed devices.
-# 3. (Optional) In a distributed training setting, the training dataset is often partitioned.
-# 4. (Optional) Scaling the learning rate of your local optimizer
+# 2. (Optional) In a distributed training setting, the training dataset is often partitioned.
+# 3. (Optional) Scaling the learning rate of your local optimizer
 
 import argparse
 import os
@@ -20,14 +18,12 @@ from kungfu import current_cluster_size, current_rank
 from kungfu.tensorflow.v1.helpers.mnist import load_datasets
 
 
-# TODO add an explaination what the function does
 def save_vars(sess, variables, filename):
     values = sess.run(variables)
     npz = dict((var.name, val) for var, val in zip(variables, values))
     np.savez(filename, **npz)
 
 
-# TODO add an explaination what the function does
 def save_all(sess, prefix):
     g = tf.get_default_graph()
     filename = '%s-%d.npz' % (prefix, os.getpid())
@@ -35,13 +31,11 @@ def save_all(sess, prefix):
 
 
 def load_mnist(data_dir):
-    # initialise dataset dictionary
     dataset = dict()
     dataset['training_set'] = dict()
     dataset['validation_set'] = dict()
     dataset['test_set'] = dict()
 
-    # load mnist dataset from file
     mnist = load_datasets(data_dir, normalize=True, one_hot=True)
 
     # reshape the inputs
@@ -67,20 +61,23 @@ def load_mnist(data_dir):
     return dataset
 
 
-# instanciate the optimizer
+# instantiate the optimizer
 def build_optimizer(name, n_shards=1):
     learning_rate = 0.1
 
     # Scale learning rate according to the level of data parallelism
     optimizer = tf.train.GradientDescentOptimizer(learning_rate * n_shards)
 
-    # KUNGFU: Wrap the TensorFlow optimizer with KungFu distributed optimizers.
+    # KungFu: Wrap the TensorFlow optimizer with KungFu distributed optimizers.
     if name == 'sync-sgd':
         from kungfu.tensorflow.v1.optimizers import SynchronousSGDOptimizer
         return SynchronousSGDOptimizer(optimizer)
     elif name == 'async-sgd':
         from kungfu.tensorflow.v1.optimizers import PairAveragingOptimizer
         return PairAveragingOptimizer(optimizer)
+    elif name == 'sma':
+        from kungfu.tensorflow.v1.optimizers import SynchronousAveragingOptimizer
+        return SynchronousAveragingOptimizer(optimizer)
     else:
         raise RuntimeError('unknow optimizer: %s' % name)
 
@@ -102,7 +99,7 @@ def build_model(optimizer):
     # minimise the loss
     train_op = optimizer.minimize(loss)
 
-    # calculate the number of correctly classifed datapoints
+    # calculate the number of correctly classified datapoints
     correct_prediction = tf.equal(tf.argmax(y, 1), tf.argmax(y_, 1))
     test_op = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
 
@@ -144,7 +141,7 @@ def train_mnist(sess,
     n_steps = step_per_epoch * n_epochs
     print('step_per_epoch: %d, %d steps in total' % (step_per_epoch, n_steps))
 
-    # KUNGFU: Each replica is responsible for a data shard.
+    # KungFu: Each replica is responsible for a data shard.
     offset = batch_size * shard_id
 
     sess.run(tf.global_variables_initializer())

--- a/srcs/python/kungfu/tensorflow/v1/ops/local.py
+++ b/srcs/python/kungfu/tensorflow/v1/ops/local.py
@@ -1,7 +1,7 @@
 from ._tf_oplib import _op_lib
 
 
-def save_variable(t, version=None):
+def save_variable(t, name=None, version=None):
     """
     t: the tensor variable to save
     version: a scalar tensor of int64 or None
@@ -11,9 +11,11 @@ def save_variable(t, version=None):
         use_version = False
     else:
         use_version = True
+    if name is None:
+        name = t.name
     return _op_lib.kungfu_save_variable(version,
                                         t,
-                                        input_tensor_name=t.name,
+                                        input_tensor_name=name,
                                         use_version=use_version)
 
 

--- a/srcs/python/kungfu/tensorflow/v1/ops/local.py
+++ b/srcs/python/kungfu/tensorflow/v1/ops/local.py
@@ -1,7 +1,7 @@
 from ._tf_oplib import _op_lib
 
 
-def save_variable(t, name=None, version=None):
+def save_variable(t, version=None, name=None):
     """
     t: the tensor variable to save
     version: a scalar tensor of int64 or None

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/__init__.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/__init__.py
@@ -1,5 +1,6 @@
 from .ada_sgd import AdaptiveSGDOptimizer
 from .async_sgd import PairAveragingOptimizer
+from .keras import KerasInitCallback
 from .sma_sgd import SynchronousAveragingOptimizer
 from .sync_sgd import (SynchronousSGDOptimizer,
                        SyncSGDWithGradNoiseScaleOptimizer,
@@ -8,4 +9,6 @@ from .sync_sgd import (SynchronousSGDOptimizer,
 __all__ = [
     'PairAveragingOptimizer',
     'SynchronousSGDOptimizer',
+    'SynchronousAveragingOptimizer',
+    'KerasInitCallback',
 ]

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/async_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/async_sgd.py
@@ -52,7 +52,6 @@ class PairAveragingOptimizer(KungFuOptimizer):
         super(PairAveragingOptimizer, self).__init__(optimizer, name,
                                                      use_locking)
         self._fuse_variables = fuse_variables
-        self._step = tf.Variable(0, trainable=False, dtype=tf.int32)
 
     def _build_request_ops(self, target, variables):
         if self._fuse_variables:
@@ -75,20 +74,13 @@ class PairAveragingOptimizer(KungFuOptimizer):
         else:
             return tf.group([save_variable(v) for v in variables])
 
-    def compute_gradients(self, *args, **kwargs):
-        self._sync_state_op = tf.cond(tf.equal(self._step, 0),
-                                      self.distributed_initializer, tf.no_op)
-        with tf.control_dependencies([self._sync_state_op]):
-            with tf.control_dependencies([tf.assign_add(self._step, 1)]):
-                return self._optimizer.compute_gradients(*args, **kwargs)
-
     def apply_gradients(self, grads_and_vars, **kwargs):
         """Calls this same method on the underlying optimizer."""
         np, rank = current_cluster_size(), current_rank()
         target = get_random_peer(np, rank)
         variables = [v for _g, v in grads_and_vars]
 
-        with tf.control_dependencies([self._sync_state_op]):
+        with tf.control_dependencies([self._init_op]):
             other_peer_vars = self._build_request_ops(target, variables)
 
         save_model_op = self._build_save_op(variables)
@@ -105,11 +97,8 @@ class PairAveragingOptimizer(KungFuOptimizer):
                 with tf.control_dependencies([save_model_op]):
                     return tf.group(apply_op)
 
-    def distributed_initializer(self):
-        bcast_ops = []
-        for v in self.variables():
-            bcast_ops.append(tf.assign(v, broadcast(v)))
-
+    def _distributed_initializer(self):
+        bcast_ops = [tf.assign(v, broadcast(v)) for v in tf.global_variables()]
         variables = tf.trainable_variables()
         with tf.control_dependencies(bcast_ops):
             with tf.control_dependencies([self._build_save_op(variables)]):

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/async_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/async_sgd.py
@@ -14,18 +14,17 @@ def get_random_peer(cluster_size, self_rank):
 
 
 class PairAveragingOptimizer(KungFuOptimizer):
-    """PairAveragingOptimizer implements communication-efficient asynchronous training.
+    """PairAveragingOptimizer implements the [AD-PSGD]_ algorithm.
 
-    Every iteration of training, this optimizer
-    (1) Randomly selects a peer in the current cluster.
-    (2) Pulls the selected peer's model
-    (3) Performs model averaging with the local model.
-    (4) Applies local gradients
-    (5) Saves the model to a local store which allows other peers to pull from.
+    Every iteration of training, this optimizer:
 
-    This optimizer realizes the principle proposed in the following paper:
-    Asynchronous Decentralized Parallel Stochastic Gradient Descent, ICML 2018
-    https://arxiv.org/abs/1710.06952
+    1. Randomly selects a peer in the current cluster.
+    2. Pulls the selected peer's model
+    3. Performs model averaging with the local model.
+    4. Applies local gradients
+    5. Saves the model to a local store which allows other peers to pull from.
+
+    .. [AD-PSGD] `Asynchronous Decentralized Parallel Stochastic Gradient Descent<https://arxiv.org/abs/1710.06952>`_
 
     Args:
       optimizer:

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/async_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/async_sgd.py
@@ -24,7 +24,7 @@ class PairAveragingOptimizer(KungFuOptimizer):
     4. Applies local gradients
     5. Saves the model to a local store which allows other peers to pull from.
 
-    .. [AD-PSGD] `Asynchronous Decentralized Parallel Stochastic Gradient Descent<https://arxiv.org/abs/1710.06952>`_
+    .. [AD-PSGD] Asynchronous Decentralized Parallel Stochastic Gradient Descent, ICML 2018, `AD-PSGD Paper <https://arxiv.org/abs/1710.06952>`_
 
     Args:
       optimizer:

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/core.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/core.py
@@ -27,16 +27,16 @@ class KungFuOptimizer(tf.train.Optimizer):
         super(KungFuOptimizer, self).__init__(name=name,
                                               use_locking=use_locking)
         self._optimizer = optimizer
-        self._step = tf.Variable(0, trainable=False, dtype=tf.int32)
+        self._kf_step = tf.Variable(0, trainable=False, dtype=tf.int32)
 
     def _distributed_initializer(self):
         raise RuntimeError('_distributed_initializer is not implemented.')
 
     def compute_gradients(self, *args, **kwargs):
-        self._init_op = tf.cond(tf.equal(self._step, 0),
+        self._init_op = tf.cond(tf.equal(self._kf_step, 0),
                                 self._distributed_initializer, tf.no_op)
         with tf.control_dependencies([self._init_op]):
-            with tf.control_dependencies([tf.assign_add(self._step, 1)]):
+            with tf.control_dependencies([tf.assign_add(self._kf_step, 1)]):
                 return self._optimizer.compute_gradients(*args, **kwargs)
 
     def apply_gradients(self, *args, **kwargs):

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/core.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/core.py
@@ -27,16 +27,17 @@ class KungFuOptimizer(tf.train.Optimizer):
         super(KungFuOptimizer, self).__init__(name=name,
                                               use_locking=use_locking)
         self._optimizer = optimizer
+        self._step = tf.Variable(0, trainable=False, dtype=tf.int32)
 
-    # distributed_initializer must be called after minimize
-    def distributed_initializer(self):
-        raise RuntimeError(
-            'Distributed optimizers must implement how variables are replicated.'
-        )
+    def _distributed_initializer(self):
+        raise RuntimeError('_distributed_initializer is not implemented.')
 
     def compute_gradients(self, *args, **kwargs):
-        """Compute gradients and negotiate with peers."""
-        return self._optimizer.compute_gradients(*args, **kwargs)
+        self._init_op = tf.cond(tf.equal(self._step, 0),
+                                self._distributed_initializer, tf.no_op)
+        with tf.control_dependencies([self._init_op]):
+            with tf.control_dependencies([tf.assign_add(self._step, 1)]):
+                return self._optimizer.compute_gradients(*args, **kwargs)
 
     def apply_gradients(self, *args, **kwargs):
         """Calls this same method on the underlying optimizer."""

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/core.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/core.py
@@ -20,7 +20,6 @@ def defuse(y, shapes):
 
 
 class KungFuOptimizer(tf.train.Optimizer):
-    """An optimizer that would negotiate the gradients before apply it."""
     def __init__(self, optimizer, name=None, use_locking=False):
         if name is None:
             name = "KungFu{}".format(type(optimizer).__name__)
@@ -40,17 +39,13 @@ class KungFuOptimizer(tf.train.Optimizer):
                 return self._optimizer.compute_gradients(*args, **kwargs)
 
     def apply_gradients(self, *args, **kwargs):
-        """Calls this same method on the underlying optimizer."""
         return self._optimizer.apply_gradients(*args, **kwargs)
 
     def get_slot(self, *args, **kwargs):
-        """Calls this same method on the underlying optimizer."""
         return self._optimizer.get_slot(*args, **kwargs)
 
     def get_slot_names(self, *args, **kwargs):
-        """Calls this same method on the underlying optimizer."""
         return self._optimizer.get_slot_names(*args, **kwargs)
 
     def variables(self, *args, **kwargs):
-        """Calls this same method on the underlying optimizer."""
         return self._optimizer.variables(*args, **kwargs)

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/keras.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/keras.py
@@ -1,0 +1,6 @@
+import tensorflow as tf
+
+
+class KerasInitCallback(tf.keras.callbacks.Callback):
+    def on_train_begin(self, logs=None):
+        tf.keras.backend.get_session().run(tf.global_variables_initializer())

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/keras.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/keras.py
@@ -2,5 +2,10 @@ import tensorflow as tf
 
 
 class KerasInitCallback(tf.keras.callbacks.Callback):
+    """Initialize the KungFu step variable using session.
+
+    This callback is given as a hook to the keras.model.compile() method.
+
+    """
     def on_train_begin(self, logs=None):
         tf.keras.backend.get_session().run(tf.global_variables_initializer())

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/sma_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/sma_sgd.py
@@ -6,16 +6,14 @@ from .core import KungFuOptimizer
 
 
 class SynchronousAveragingOptimizer(KungFuOptimizer):
-    """SynchronousAveragingOptimizer implements the small-batch-efficient model averaging algorithm [1][2].
+    """SynchronousAveragingOptimizer implements the [SMA]_ algorithm.
 
-    EA-SGD [1] proposed to use model averaging to train deep learning models and prove its convergence.
-    CrossBow [2] further improves [1] results and show model averaging can benefit small-batch training
+    [EA-SGD]_ proposed to use model averaging to train deep learning models and prove its convergence.
+    [SMA]_ further improves [EA-SGD]_ results and show model averaging can benefit small-batch training
     and achieves fast convergence compared to synchronous SGD.
 
-    [1] Deep learning with Elastic Averaging SGD, NIPS 2015
-    https://arxiv.org/abs/1412.6651
-    [2] CrossBow: Scaling Deep Learning with Small Batch Sizes on Multi-GPU Servers, VLDB 2019
-    http://www.vldb.org/pvldb/vol12/p1399-koliousis.pdf
+    .. [EA-SGD] Deep learning with Elastic Averaging SGD, NIPS 2015, `EA-SGD Paper <https://arxiv.org/abs/1412.6651>`_
+    .. [SMA] CrossBow: Scaling Deep Learning with Small Batch Sizes on Multi-GPU Servers, VLDB 2019, `SMA Paper <http://www.vldb.org/pvldb/vol12/p1399-koliousis.pdf>`_
 
     Args:
       optimizer:

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/sma_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/sma_sgd.py
@@ -50,6 +50,6 @@ class SynchronousAveragingOptimizer(KungFuOptimizer):
         with tf.control_dependencies(assign_ops):
             return self._optimizer.apply_gradients(grads_and_vars, **kwargs)
 
-    def distributed_initializer(self):
-        ops = [tf.assign(v, broadcast(v)) for v in self.variables()]
+    def _distributed_initializer(self):
+        ops = [tf.assign(v, broadcast(v)) for v in tf.global_variables()]
         return tf.group(ops)

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/sync_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/sync_sgd.py
@@ -7,14 +7,13 @@ from .core import KungFuOptimizer, defuse, fuse
 
 
 class SynchronousSGDOptimizer(KungFuOptimizer):
-    """SynchronousSGDOptimizer implements the synchronous SGD algorithm.
+    """SynchronousSGDOptimizer implements [S-SGD]_.
 
+    This optimizer is equivalent to the DistributedOptimizer in Horovod.
     Every iteration of training, this optimizer computes the averaged gradients
-    to correct all model replicas.
+    to correct diverged model replicas.
 
-    More details about this algorithm can be found here:
-    Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour
-    https://arxiv.org/pdf/1706.02677
+    .. [S-SGD] `Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour<https://arxiv.org/pdf/1706.02677>`_
 
     Args:
       optimizer:

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/sync_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/sync_sgd.py
@@ -67,8 +67,8 @@ class SynchronousSGDOptimizer(KungFuOptimizer):
         return self._optimizer.apply_gradients(reduced_grads_and_vars,
                                                **kwargs)
 
-    def distributed_initializer(self):
-        ops = [tf.assign(v, broadcast(v)) for v in self.variables()]
+    def _distributed_initializer(self):
+        ops = [tf.assign(v, broadcast(v)) for v in tf.global_variables()]
         return tf.group(ops)
 
 
@@ -150,8 +150,8 @@ class SyncSGDWithGradVarianceOptimizer(KungFuOptimizer):
                 return self._optimizer.apply_gradients(
                     zip(reduced_grads, variables), **kwargs)
 
-    def distributed_initializer(self):
-        ops = [tf.assign(v, broadcast(v)) for v in self.variables()]
+    def _distributed_initializer(self):
+        ops = [tf.assign(v, broadcast(v)) for v in tf.global_variables()]
         return tf.group(ops)
 
 
@@ -229,6 +229,6 @@ class SyncSGDWithGradNoiseScaleOptimizer(KungFuOptimizer):
                 return self._optimizer.apply_gradients(
                     zip(reduced_grads, variables), **kwargs)
 
-    def distributed_initializer(self):
-        ops = [tf.assign(v, broadcast(v)) for v in self.variables()]
+    def _distributed_initializer(self):
+        ops = [tf.assign(v, broadcast(v)) for v in tf.global_variables()]
         return tf.group(ops)

--- a/srcs/python/kungfu/tensorflow/v1/optimizers/sync_sgd.py
+++ b/srcs/python/kungfu/tensorflow/v1/optimizers/sync_sgd.py
@@ -7,13 +7,13 @@ from .core import KungFuOptimizer, defuse, fuse
 
 
 class SynchronousSGDOptimizer(KungFuOptimizer):
-    """SynchronousSGDOptimizer implements [S-SGD]_.
+    """SynchronousSGDOptimizer implements the [S-SGD]_ algorithm.
 
     This optimizer is equivalent to the DistributedOptimizer in Horovod.
     Every iteration of training, this optimizer computes the averaged gradients
     to correct diverged model replicas.
 
-    .. [S-SGD] `Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour<https://arxiv.org/pdf/1706.02677>`_
+    .. [S-SGD] Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour, 2017, `S-SGD Paper <https://arxiv.org/pdf/1706.02677>`_
 
     Args:
       optimizer:

--- a/tests/python/test_operators.py
+++ b/tests/python/test_operators.py
@@ -15,15 +15,14 @@ def test_peer_info():
 
 
 def test_save_and_request():
-    global_step = tf.Variable(tf.constant(0, dtype=tf.int64),
-                              name='global_step')
+    global_step = tf.Variable(tf.constant(0, dtype=tf.int64))
     target = tf.Variable(tf.constant(0, dtype=tf.int32))
 
     x = tf.Variable(tf.zeros([10], dtype=tf.int32))
 
     inc_op = tf.assign_add(global_step, 1)
     update_op = tf.assign(x, x + 1)
-    save_op = save_variable(x, global_step)
+    save_op = save_variable(x, version=global_step)
     y = request_variable(target, global_step, x.name, x.shape, x.dtype)
 
     with tf.Session() as sess:

--- a/tests/python/test_operators.py
+++ b/tests/python/test_operators.py
@@ -15,7 +15,8 @@ def test_peer_info():
 
 
 def test_save_and_request():
-    global_step = tf.Variable(tf.constant(0, dtype=tf.int64))
+    global_step = tf.Variable(tf.constant(0, dtype=tf.int64),
+                              name='global_step')
     target = tf.Variable(tf.constant(0, dtype=tf.int32))
 
     x = tf.Variable(tf.zeros([10], dtype=tf.int32))

--- a/tests/python/test_optimizers.py
+++ b/tests/python/test_optimizers.py
@@ -11,7 +11,6 @@ def test_sync_sgd():
     train_op = optimizer.minimize(y)
     with tf.Session() as sess:
         sess.run(tf.global_variables_initializer())
-        sess.run(optimizer.distributed_initializer())
         for _ in range(2):
             sess.run(train_op)
         # FIXME: check values
@@ -25,7 +24,6 @@ def test_pair_averaging():
     train_op = optimizer.minimize(y)
     with tf.Session() as sess:
         sess.run(tf.global_variables_initializer())
-        sess.run(optimizer.distributed_initializer())
         for _ in range(2):
             sess.run(train_op)
         # FIXME: check values


### PR DESCRIPTION
KungFu can now automatically handle the initialisation in the TensorFlow case. 

However, in the TensorFlow Keras case, I have to provide a KerasInitCallback as the KungFu step is a tf.Variable and it is not initialised by TensorFlow Keras. I have to pass the callback to keras as hooks so that it will initialise the KungFu step. 