### PR TITLE
Use multiple communication strategies to fully utilise the network.

### DIFF
--- a/benchmarks/system/benchmark_kungfu.py
+++ b/benchmarks/system/benchmark_kungfu.py
@@ -139,7 +139,11 @@ device = '/gpu:0' if args.cuda else 'CPU'
 def run(benchmark_step):
     # Warm-up
     log('Running warmup...')
-    timeit.timeit(benchmark_step, number=args.num_warmup_batches)
+    for x in range(args.num_warmup_batches):
+        time = timeit.timeit(benchmark_step, number=1)
+        img_sec = args.batch_size / time
+        log('Warmup Step #%d: %.1f img/sec per %s, took %.3fs' %
+            (x, img_sec, device, time))
 
     # Benchmark
     log('Running benchmark...')

--- a/scripts/tests/run-integration-tests.sh
+++ b/scripts/tests/run-integration-tests.sh
@@ -28,7 +28,7 @@ run_fake_cluster() {
 }
 
 test_all() {
-    all_strategies="STAR RING CLIQUE TREE BINARY_TREE BINARY_TREE_STAR AUTO"
+    all_strategies="STAR RING CLIQUE TREE BINARY_TREE BINARY_TREE_STAR MULTI_BINARY_TREE_STAR AUTO"
     for np in $(seq 4); do
         for STRATEGY in $all_strategies; do
             run_fake_cluster $np $STRATEGY ./bin/fake-agent

--- a/srcs/cpp/include/kungfu/strategy.h
+++ b/srcs/cpp/include/kungfu/strategy.h
@@ -11,6 +11,7 @@ enum KungFu_Strategy {
     KungFu_Star,
     KungFu_Clique,
     KungFu_BinaryTreeStar,
+    KungFu_MultiBinaryTreeStar,
     KungFu_AUTO,
 };
 

--- a/srcs/go/kungfu/monitoring.go
+++ b/srcs/go/kungfu/monitoring.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lsds/KungFu/srcs/go/log"
 	"github.com/lsds/KungFu/srcs/go/plan"
 	rch "github.com/lsds/KungFu/srcs/go/rchannel"
 )
@@ -28,23 +27,9 @@ func (sess *session) GetPeerLatencies() []time.Duration {
 }
 
 func getLatency(self, peer plan.PeerID) time.Duration {
-	t0 := time.Now()
-	var conn rch.Connection
-	for i := 0; i < 10; i++ {
-		var err error
-		conn, err = rch.NewPingConnection(plan.NetAddr(self), plan.NetAddr(peer))
-		if err == nil {
-			break
-		}
-		log.Warnf("connection %d failed for %v", i+1, err)
-		time.Sleep(1 * time.Second)
-	}
-	if conn == nil {
-		// connection failed
-		return time.Since(t0)
-	}
+	conn := rch.NewPingConnection(plan.NetAddr(self), plan.NetAddr(peer))
 	defer conn.Close()
-	t0 = time.Now() // reset t0
+	t0 := time.Now()
 	var empty rch.Message
 	conn.Send("ping", empty, rch.NoFlag)
 	conn.Read("ping", empty)

--- a/srcs/go/kungfu/session.go
+++ b/srcs/go/kungfu/session.go
@@ -281,7 +281,7 @@ func ceilDiv(a, b int) int {
 	return a/b + 1
 }
 
-func (sess *session) runStrategies(w Workspace, p partitionFunc, strategies []strategy) error {
+func (sess *session) runStrategies(w Workspace, p partitionFunc, strategies strategyList) error {
 	k := ceilDiv(w.RecvBuf.Count*w.RecvBuf.Type.Size(), chunkSize)
 	errs := make([]error, k)
 	var wg sync.WaitGroup
@@ -290,7 +290,7 @@ func (sess *session) runStrategies(w Workspace, p partitionFunc, strategies []st
 		go func(i int, w Workspace, s strategy) {
 			errs[i] = sess.runGraphs(w, s.reduceGraph, s.bcastGraph)
 			wg.Done()
-		}(i, w, strategies[i%len(strategies)])
+		}(i, w, strategies.choose(i))
 	}
 	wg.Wait()
 	return mergeErrors(errs, "runStrategies")

--- a/srcs/go/kungfu/session.go
+++ b/srcs/go/kungfu/session.go
@@ -292,7 +292,7 @@ func (sess *session) runStrategiesWithHash(w Workspace, p partitionFunc, strateg
 		go func(i int, w Workspace, s strategy) {
 			errs[i] = sess.runGraphs(w, s.reduceGraph, s.bcastGraph)
 			wg.Done()
-		}(i, w, strategies.choose(shardHash(i, w.Name)))
+		}(i, w, strategies.choose(int(shardHash(i, w.Name))))
 	}
 	wg.Wait()
 	return mergeErrors(errs, "runStrategies")

--- a/srcs/go/kungfu/strategy.go
+++ b/srcs/go/kungfu/strategy.go
@@ -14,12 +14,13 @@ func (sl strategyList) choose(i int) strategy {
 }
 
 var partitionStrategies = map[kb.Strategy]partitionStrategy{
-	kb.Star:           createStarStrategies,
-	kb.Clique:         createCliqueStrategies,
-	kb.Ring:           createRingStrategies,
-	kb.Tree:           createTreeStrategies,
-	kb.BinaryTree:     createBinaryTreeStrategies,
-	kb.BinaryTreeStar: createBinaryTreeStarStrategies,
+	kb.Star:                createStarStrategies,
+	kb.Clique:              createCliqueStrategies,
+	kb.Ring:                createRingStrategies,
+	kb.Tree:                createTreeStrategies,
+	kb.BinaryTree:          createBinaryTreeStrategies,
+	kb.BinaryTreeStar:      createBinaryTreeStarStrategies,
+	kb.MultiBinaryTreeStar: createMultiBinaryTreeStarStrategies,
 }
 
 func simpleSingleGraphStrategy(bcastGraph *plan.Graph) []strategy {
@@ -49,6 +50,17 @@ func createBinaryTreeStrategies(peers plan.PeerList) []strategy {
 func createBinaryTreeStarStrategies(peers plan.PeerList) []strategy {
 	bcastGraph := plan.GenBinaryTreeStar(peers)
 	return simpleSingleGraphStrategy(bcastGraph)
+}
+
+func createMultiBinaryTreeStarStrategies(peers plan.PeerList) []strategy {
+	var ss []strategy
+	for _, bcastGraph := range plan.GenMultiBinaryTreeStar(peers) {
+		ss = append(ss, strategy{
+			reduceGraph: plan.GenDefaultReduceGraph(bcastGraph),
+			bcastGraph:  bcastGraph,
+		})
+	}
+	return ss
 }
 
 func createCliqueStrategies(peers plan.PeerList) []strategy {

--- a/srcs/go/kungfu/strategy.go
+++ b/srcs/go/kungfu/strategy.go
@@ -7,6 +7,12 @@ import (
 
 type partitionStrategy func(plan.PeerList) []strategy
 
+type strategyList []strategy
+
+func (sl strategyList) choose(i int) strategy {
+	return sl[i%len(sl)]
+}
+
 var partitionStrategies = map[kb.Strategy]partitionStrategy{
 	kb.Star:           createStarStrategies,
 	kb.Clique:         createCliqueStrategies,

--- a/srcs/go/kungfu/workspace.go
+++ b/srcs/go/kungfu/workspace.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	kb "github.com/lsds/KungFu/srcs/go/kungfubase"
+	kc "github.com/lsds/KungFu/srcs/go/kungfuconfig"
+	"github.com/lsds/KungFu/srcs/go/log"
 	"github.com/lsds/KungFu/srcs/go/plan"
 )
 
@@ -38,4 +40,26 @@ func (w Workspace) split(p partitionFunc, k int) []Workspace {
 		ws = append(ws, w.slice(r.Begin, r.End))
 	}
 	return ws
+}
+
+type shardHashFunc func(int, string) int
+
+func simpleHash(i int, name string) int {
+	return i
+}
+
+func nameBasedHash(i int, name string) int {
+	var h int
+	for _, c := range name {
+		h += int(c) * int(c)
+	}
+	return h
+}
+
+func getshardHash() shardHashFunc {
+	if kc.ShardHashMethod == `NAME` {
+		log.Debugf("using name based hash")
+		return nameBasedHash
+	}
+	return simpleHash
 }

--- a/srcs/go/kungfu/workspace.go
+++ b/srcs/go/kungfu/workspace.go
@@ -42,16 +42,16 @@ func (w Workspace) split(p partitionFunc, k int) []Workspace {
 	return ws
 }
 
-type shardHashFunc func(int, string) int
+type shardHashFunc func(int, string) uint64
 
-func simpleHash(i int, name string) int {
-	return i
+func simpleHash(i int, name string) uint64 {
+	return uint64(i)
 }
 
-func nameBasedHash(i int, name string) int {
-	var h int
+func nameBasedHash(i int, name string) uint64 {
+	var h uint64
 	for _, c := range name {
-		h += int(c) * int(c)
+		h += uint64(c) * uint64(c)
 	}
 	return h
 }

--- a/srcs/go/kungfubase/strategy.go
+++ b/srcs/go/kungfubase/strategy.go
@@ -8,26 +8,28 @@ import "C"
 type Strategy C.KungFu_Strategy
 
 const (
-	Star           Strategy = C.KungFu_Star
-	Ring           Strategy = C.KungFu_Ring
-	Clique         Strategy = C.KungFu_Clique
-	Tree           Strategy = C.KungFu_Tree
-	BinaryTree     Strategy = C.KungFu_BinaryTree
-	BinaryTreeStar Strategy = C.KungFu_BinaryTreeStar
-	Auto           Strategy = C.KungFu_AUTO
+	Star                Strategy = C.KungFu_Star
+	Ring                Strategy = C.KungFu_Ring
+	Clique              Strategy = C.KungFu_Clique
+	Tree                Strategy = C.KungFu_Tree
+	BinaryTree          Strategy = C.KungFu_BinaryTree
+	BinaryTreeStar      Strategy = C.KungFu_BinaryTreeStar
+	MultiBinaryTreeStar Strategy = C.KungFu_MultiBinaryTreeStar
+	Auto                Strategy = C.KungFu_AUTO
 )
 
 const DefaultStrategy = BinaryTreeStar
 
 var (
 	strategyNames = map[Strategy]string{
-		Star:           `STAR`,
-		Ring:           `RING`,
-		Clique:         `CLIQUE`,
-		Tree:           `TREE`,
-		BinaryTree:     `BINARY_TREE`,
-		BinaryTreeStar: `BINARY_TREE_STAR`,
-		Auto:           `AUTO`,
+		Star:                `STAR`,
+		Ring:                `RING`,
+		Clique:              `CLIQUE`,
+		Tree:                `TREE`,
+		BinaryTree:          `BINARY_TREE`,
+		BinaryTreeStar:      `BINARY_TREE_STAR`,
+		MultiBinaryTreeStar: `MULTI_BINARY_TREE_STAR`,
+		Auto:                `AUTO`,
 	}
 )
 

--- a/srcs/go/kungfuconfig/config.go
+++ b/srcs/go/kungfuconfig/config.go
@@ -21,18 +21,21 @@ const (
 	EnableMonitoringEnvKey = `KUNGFU_CONFIG_ENABLE_MONITORING`
 	MonitoringPeriodEnvKey = `KUNGFU_CONFIG_MONITORING_PERIOD`
 	LogLevelEnvKey         = `KUNGFU_CONFIG_LOG_LEVEL`
+	ShardHashMethodEnvKey  = `KUNGFU_CONFIG_SHARD_HASH_METHOD`
 )
 
 var ConfigEnvKeys = []string{
 	EnableMonitoringEnvKey,
 	MonitoringPeriodEnvKey,
 	LogLevelEnvKey,
+	ShardHashMethodEnvKey,
 }
 
 var (
 	EnableMonitoring = false
 	LogLevel         = `INFO`
 	MonitoringPeriod = 1 * time.Second
+	ShardHashMethod  = `ID`
 )
 
 func init() {
@@ -44,6 +47,9 @@ func init() {
 	}
 	if val := os.Getenv(LogLevelEnvKey); len(val) > 0 {
 		LogLevel = strings.ToUpper(val)
+	}
+	if val := os.Getenv(ShardHashMethodEnvKey); len(val) > 0 {
+		ShardHashMethod = strings.ToUpper(val)
 	}
 }
 

--- a/srcs/go/plan/topology.go
+++ b/srcs/go/plan/topology.go
@@ -50,7 +50,7 @@ func GenBinaryTree(k int) *Graph {
 	return g
 }
 
-func GenBinaryTreeStar(peers PeerList) *Graph {
+func genBinaryTreeStar(peers PeerList, offset int) *Graph {
 	g := NewGraph(len(peers))
 	masters, hostMaster := getLocalMasters(peers)
 	for rank, p := range peers {
@@ -59,16 +59,33 @@ func GenBinaryTreeStar(peers PeerList) *Graph {
 		}
 	}
 	if k := len(masters); k > 1 {
+		idx := func(i int) int {
+			return (i + offset) % k
+		}
 		for i := 0; i < k; i++ {
 			if j := i*2 + 1; j < k {
-				g.AddEdge(masters[i], masters[j])
+				g.AddEdge(masters[idx(i)], masters[idx(j)])
 			}
 			if j := i*2 + 2; j < k {
-				g.AddEdge(masters[i], masters[j])
+				g.AddEdge(masters[idx(i)], masters[idx(j)])
 			}
 		}
 	}
 	return g
+}
+
+func GenBinaryTreeStar(peers PeerList) *Graph {
+	return genBinaryTreeStar(peers, 0)
+}
+
+func GenMultiBinaryTreeStar(peers PeerList) []*Graph {
+	var gs []*Graph
+	masters, _ := getLocalMasters(peers)
+	m := len(masters)
+	for i := 0; i < m; i++ {
+		gs = append(gs, genBinaryTreeStar(peers, i))
+	}
+	return gs
 }
 
 // GenStarBcastGraph generates a star shape graph with k vertices and centered at vertice r (0 <= r < k)

--- a/srcs/go/plan/topology_test.go
+++ b/srcs/go/plan/topology_test.go
@@ -80,9 +80,15 @@ func Test_trees(t *testing.T) {
 		t.Errorf("tree not generated correctly")
 	}
 	if g := GenBinaryTree(len(peers)); !isValidTreeWithRoot(g, 0) {
-		t.Errorf("tree not generated correctly")
+		t.Errorf("binary tree not generated correctly")
 	}
 	if g := GenBinaryTreeStar(peers); !isValidTreeWithRoot(g, 0) {
-		t.Errorf("tree not generated correctly")
+		t.Errorf("binary tree star not generated correctly")
+	}
+	{
+		gs := GenMultiBinaryTreeStar(peers)
+		if !isValidTreeWithRoot(gs[0], 0) {
+			t.Errorf("multi binary tree star not generated correctly")
+		}
 	}
 }

--- a/srcs/go/rchannel/connection.go
+++ b/srcs/go/rchannel/connection.go
@@ -1,11 +1,14 @@
 package rchannel
 
 import (
+	"errors"
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	kc "github.com/lsds/KungFu/srcs/go/kungfuconfig"
+	"github.com/lsds/KungFu/srcs/go/log"
 	"github.com/lsds/KungFu/srcs/go/plan"
 )
 
@@ -21,33 +24,60 @@ func NewPingConnection(remote, local plan.NetAddr) (Connection, error) {
 }
 
 func newConnection(remote, local plan.NetAddr, t ConnType) (Connection, error) {
-	conn, err := func() (net.Conn, error) {
-		if kc.UseUnixSock && remote.ColocatedWith(local) {
-			addr := net.UnixAddr{remote.SockFile(), "unix"}
-			return net.DialUnix(addr.Net, nil, &addr)
+	init := func() (net.Conn, error) {
+		conn, err := func() (net.Conn, error) {
+			if kc.UseUnixSock && remote.ColocatedWith(local) {
+				addr := net.UnixAddr{Name: remote.SockFile(), Net: "unix"}
+				return net.DialUnix(addr.Net, nil, &addr)
+			}
+			return net.Dial("tcp", remote.String())
+		}()
+		if err != nil {
+			return nil, err
 		}
-		return net.Dial("tcp", remote.String())
-	}()
-	if err != nil {
-		return nil, err
+		h := connectionHeader{
+			Type:    uint16(t),
+			SrcIPv4: local.IPv4,
+			SrcPort: local.Port,
+		}
+		if err := h.WriteTo(conn); err != nil {
+			return nil, err
+		}
+		return conn, nil
 	}
-	h := connectionHeader{
-		Type:    uint16(t),
-		SrcIPv4: local.IPv4,
-		SrcPort: local.Port,
-	}
-	if err := h.WriteTo(conn); err != nil {
-		return nil, err
-	}
-	return &tcpConnection{conn: conn}, nil
+	return &tcpConnection{remote: remote, init: init}, nil
 }
 
 type tcpConnection struct {
 	sync.Mutex
-	conn net.Conn
+	remote plan.NetAddr
+	init   func() (net.Conn, error)
+	conn   net.Conn
+}
+
+var errCantEstablishConnection = errors.New("can't establish connection")
+
+func (c *tcpConnection) initOnce() error {
+	c.Lock()
+	defer c.Unlock()
+	if c.conn != nil {
+		return nil
+	}
+	t0 := time.Now()
+	for i := 0; i <= kc.ConnRetryCount; i++ {
+		var err error
+		if c.conn, err = c.init(); err == nil {
+			log.Debugf("connection to #<%s> established after %d trials, took %s", c.remote, i+1, time.Since(t0))
+			return nil
+		}
+		log.Debugf("failed to establish connection to #<%s> for %d times: %v", c.remote, i+1, err)
+		time.Sleep(kc.ConnRetryPeriod)
+	}
+	return errCantEstablishConnection
 }
 
 func (c *tcpConnection) Send(msgName string, m Message, flags uint32) error {
+	c.initOnce()
 	c.Lock()
 	defer c.Unlock()
 	bs := []byte(msgName)
@@ -63,6 +93,7 @@ func (c *tcpConnection) Send(msgName string, m Message, flags uint32) error {
 }
 
 func (c *tcpConnection) Read(msgName string, m Message) error {
+	c.initOnce()
 	c.Lock()
 	defer c.Unlock()
 	var mh messageHeader
@@ -73,5 +104,7 @@ func (c *tcpConnection) Read(msgName string, m Message) error {
 }
 
 func (c *tcpConnection) Close() error {
+	c.Lock()
+	defer c.Unlock()
 	return c.conn.Close()
 }

--- a/srcs/go/rchannel/connection_pool.go
+++ b/srcs/go/rchannel/connection_pool.go
@@ -41,19 +41,18 @@ func (p *ConnectionPool) get(remote, local plan.NetAddr, t ConnType) (Connection
 	if conn, ok := p.conns[key]; ok {
 		return conn, nil
 	}
-
-	log.Debugf("New connection to %s", remote)
+	t0 := time.Now()
 	for i := 0; i <= p.connRetryCount; i++ {
 		// TODO: call newConnection with timeout.
 		conn, err := newConnection(remote, local, t)
 		if err == nil {
+			log.Debugf("got new connection to #<%s> after %d trials, took %s", remote, i+1, time.Since(t0))
 			p.conns[key] = conn
 			return conn, nil
 		}
-		log.Debugf("Retry connect to [%s] for [%d] times. Retry after %s. Error: %v. ", remote, i+1, p.connRetryPeriod, err)
+		log.Debugf("Retry connect to #<%s> for %d times. Retry after %s. Error: %v. ", remote, i+1, p.connRetryPeriod, err)
 		time.Sleep(p.connRetryPeriod)
 	}
-
 	return nil, errCantEstablishConnection
 }
 

--- a/srcs/go/rchannel/connection_pool.go
+++ b/srcs/go/rchannel/connection_pool.go
@@ -22,19 +22,16 @@ func newConnectionPool() *ConnectionPool {
 	}
 }
 
-func (p *ConnectionPool) get(remote, local plan.NetAddr, t ConnType) (Connection, error) {
+func (p *ConnectionPool) get(remote, local plan.NetAddr, t ConnType) Connection {
 	p.Lock()
 	defer p.Unlock()
 	key := connKey{remote, t}
 	if conn, ok := p.conns[key]; ok {
-		return conn, nil
+		return conn
 	}
-	conn, err := newConnection(remote, local, t)
-	if err != nil {
-		return nil, err
-	}
+	conn := newConnection(remote, local, t)
 	p.conns[key] = conn
-	return conn, nil
+	return conn
 }
 
 func (p *ConnectionPool) reset(keeps plan.PeerList) {

--- a/srcs/go/rchannel/router.go
+++ b/srcs/go/rchannel/router.go
@@ -49,10 +49,7 @@ func (r *Router) Send(a plan.Addr, buf []byte, t ConnType, flags uint32) error {
 }
 
 func (r *Router) send(a plan.Addr, msg Message, t ConnType, flags uint32) error {
-	conn, err := r.connPool.get(a.NetAddr(), r.localAddr, t)
-	if err != nil {
-		return err
-	}
+	conn := r.connPool.get(a.NetAddr(), r.localAddr, t)
 	if err := conn.Send(a.Name, msg, flags); err != nil {
 		return err
 	}

--- a/srcs/go/utils/runner/local/local.go
+++ b/srcs/go/utils/runner/local/local.go
@@ -85,7 +85,7 @@ func RunAll(ctx context.Context, ps []job.Proc, verboseLog bool) error {
 		go func(i int, proc job.Proc) {
 			r := &Runner{
 				name:          proc.Name,
-				color:         xterm.BasicColors.Get(i),
+				color:         xterm.BasicColors.Choose(i),
 				verboseLog:    verboseLog,
 				logFilePrefix: strings.Replace(proc.Name, "/", "-", -1),
 				logDir:        proc.LogDir,

--- a/srcs/go/utils/runner/remote/remote.go
+++ b/srcs/go/utils/runner/remote/remote.go
@@ -37,7 +37,7 @@ func RemoteRunAll(ctx context.Context, user string, ps []job.Proc, verboseLog bo
 			}
 			var redirectors []*iostream.StdWriters
 			if verboseLog {
-				redirectors = append(redirectors, iostream.NewXTermRedirector(p.Name, xterm.BasicColors.Get(i)))
+				redirectors = append(redirectors, iostream.NewXTermRedirector(p.Name, xterm.BasicColors.Choose(i)))
 			}
 			redirectors = append(redirectors, iostream.NewFileRedirector(path.Join(logDir, p.Name)))
 			if err := client.Watch(ctx, p.Script(), redirectors); err != nil {

--- a/srcs/go/utils/xterm/color.go
+++ b/srcs/go/utils/xterm/color.go
@@ -7,7 +7,7 @@ import (
 
 type ColorSet []Color
 
-func (cs ColorSet) Get(i int) Color {
+func (cs ColorSet) Choose(i int) Color {
 	return cs[i%len(cs)]
 }
 


### PR DESCRIPTION
```
kungfu@relay:~/run-distributed-experiments$ ./experiments/tf-train.sh
Using H=10.0.0.35:1,10.0.0.18:1,10.0.0.25:1,10.0.0.40:1,10.0.0.9:1,10.0.0.22:1,10.0.0.38:1,10.0.0.41:1,10.0.0.8:1,10.0.0.13:1,10.0.0.28:1,10.0.0.19:1,10.0.0.24:1,10.0.0.42:1,10.0.0.10:1,10.0.0.27:1,10.0.0.43:1,10.0.0.12:1,10.0.0.21:1,10.0.0.30:1,10.0.0.20:1,10.0.0.11:1,10.0.0.16:1,10.0.0.36:1,10.0.0.32:1,10.0.0.39:1,10.0.0.23:1,10.0.0.45:1,10.0.0.37:1,10.0.0.44:1,10.0.0.7:1,10.0.0.15:1,10.0.0.33:1,10.0.0.29:1,10.0.0.31:1,10.0.0.6:1,10.0.0.17:1,10.0.0.34:1,10.0.0.14:1,10.0.0.26:1
Using np=40


Running KUNGFU with python3 ./tmp/KungFu/benchmarks/system/benchmark_kungfu.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4 --kf-optimizer sync-sgd
[I] Using 40 hosts
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Model: ResNet50
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Batch size: 32
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] init took 0.932s
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] bcast_op took 0.928s
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Running warmup...
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Running benchmark...
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #0: 31.2 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #1: 31.0 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #2: 31.8 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #3: 29.7 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Img/sec per /gpu:0: 30.9 +-1.5
[I] kungfu-distribute `env PATH=$HOME/go/bin:$PATH TF_CPP_MIN_LOG_LEVEL=3 STD_TRACER_REPORT_STDOUT=0 KUNGFU_CONFIG_LOG_LEVEL=ERROR KUNGFU_CONFIG_SHARD_HASH_METHOD=NAME kungfu-run -q -logdir logs -H 10.0.0.35:1,10.0.0.18:1,10.0.0.25:1,10.0.0.40:1,10.0.0.9:1,10.0.0.22:1,10.0.0.38:1,10.0.0.41:1,10.0.0.8:1,10.0.0.13:1,10.0.0.28:1,10.0.0.19:1,10.0.0.24:1,10.0.0.42:1,10.0.0.10:1,10.0.0.27:1,10.0.0.43:1,10.0.0.12:1,10.0.0.21:1,10.0.0.30:1,10.0.0.20:1,10.0.0.11:1,10.0.0.16:1,10.0.0.36:1,10.0.0.32:1,10.0.0.39:1,10.0.0.23:1,10.0.0.45:1,10.0.0.37:1,10.0.0.44:1,10.0.0.7:1,10.0.0.15:1,10.0.0.33:1,10.0.0.29:1,10.0.0.31:1,10.0.0.6:1,10.0.0.17:1,10.0.0.34:1,10.0.0.14:1,10.0.0.26:1 -np 40 -nic eth0 python3 ./tmp/KungFu/benchmarks/system/benchmark_kungfu.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4 --kf-optimizer sync-sgd` took 48.245848793s


Running KUNGFU with --strategy RING python3 ./tmp/KungFu/benchmarks/system/benchmark_kungfu.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4 --kf-optimizer sync-sgd
[I] Using 40 hosts
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Model: ResNet50
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Batch size: 32
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] init took 0.921s
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] bcast_op took 0.937s
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Running warmup...
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Running benchmark...
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #0: 25.6 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #1: 25.9 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #2: 25.8 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #3: 25.4 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Img/sec per /gpu:0: 25.7 +-0.4
[I] kungfu-distribute `env PATH=$HOME/go/bin:$PATH TF_CPP_MIN_LOG_LEVEL=3 STD_TRACER_REPORT_STDOUT=0 KUNGFU_CONFIG_LOG_LEVEL=ERROR KUNGFU_CONFIG_SHARD_HASH_METHOD=NAME kungfu-run -q -logdir logs -H 10.0.0.35:1,10.0.0.18:1,10.0.0.25:1,10.0.0.40:1,10.0.0.9:1,10.0.0.22:1,10.0.0.38:1,10.0.0.41:1,10.0.0.8:1,10.0.0.13:1,10.0.0.28:1,10.0.0.19:1,10.0.0.24:1,10.0.0.42:1,10.0.0.10:1,10.0.0.27:1,10.0.0.43:1,10.0.0.12:1,10.0.0.21:1,10.0.0.30:1,10.0.0.20:1,10.0.0.11:1,10.0.0.16:1,10.0.0.36:1,10.0.0.32:1,10.0.0.39:1,10.0.0.23:1,10.0.0.45:1,10.0.0.37:1,10.0.0.44:1,10.0.0.7:1,10.0.0.15:1,10.0.0.33:1,10.0.0.29:1,10.0.0.31:1,10.0.0.6:1,10.0.0.17:1,10.0.0.34:1,10.0.0.14:1,10.0.0.26:1 -np 40 -nic eth0 --strategy RING python3 ./tmp/KungFu/benchmarks/system/benchmark_kungfu.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4 --kf-optimizer sync-sgd` took 39.987294215s


Running KUNGFU with --strategy MULTI_BINARY_TREE_STAR python3 ./tmp/KungFu/benchmarks/system/benchmark_kungfu.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4 --kf-optimizer sync-sgd
[I] Using 40 hosts
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Model: ResNet50
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Batch size: 32
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] init took 0.966s
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] bcast_op took 0.844s
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Running warmup...
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Running benchmark...
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #0: 44.8 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #1: 45.2 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #2: 44.6 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Iter #3: 44.4 img/sec per /gpu:0
[10.0.0.35::stdout] [10.0.0.35.10000::stdout] Img/sec per /gpu:0: 44.8 +-0.6
[I] kungfu-distribute `env PATH=$HOME/go/bin:$PATH TF_CPP_MIN_LOG_LEVEL=3 STD_TRACER_REPORT_STDOUT=0 KUNGFU_CONFIG_LOG_LEVEL=ERROR KUNGFU_CONFIG_SHARD_HASH_METHOD=NAME kungfu-run -q -logdir logs -H 10.0.0.35:1,10.0.0.18:1,10.0.0.25:1,10.0.0.40:1,10.0.0.9:1,10.0.0.22:1,10.0.0.38:1,10.0.0.41:1,10.0.0.8:1,10.0.0.13:1,10.0.0.28:1,10.0.0.19:1,10.0.0.24:1,10.0.0.42:1,10.0.0.10:1,10.0.0.27:1,10.0.0.43:1,10.0.0.12:1,10.0.0.21:1,10.0.0.30:1,10.0.0.20:1,10.0.0.11:1,10.0.0.16:1,10.0.0.36:1,10.0.0.32:1,10.0.0.39:1,10.0.0.23:1,10.0.0.45:1,10.0.0.37:1,10.0.0.44:1,10.0.0.7:1,10.0.0.15:1,10.0.0.33:1,10.0.0.29:1,10.0.0.31:1,10.0.0.6:1,10.0.0.17:1,10.0.0.34:1,10.0.0.14:1,10.0.0.26:1 -np 40 -nic eth0 --strategy MULTI_BINARY_TREE_STAR python3 ./tmp/KungFu/benchmarks/system/benchmark_kungfu.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4 --kf-optimizer sync-sgd` took 29.316894372s


Running MPI with python3 ./tmp/KungFu/benchmarks/system/benchmark_horovod.py --num-warmup-batches 4 --num-batches-per-iter 4 --num-iters 4
Model: ResNet50
Batch size: 32
Number of GPUs: 40
Running warmup...
Running benchmark...
Iter #0: 19.9 img/sec per GPU
Iter #1: 14.7 img/sec per GPU
Iter #2: 17.4 img/sec per GPU
Iter #3: 21.0 img/sec per GPU
Img/sec per GPU: 18.3 +-4.8
Total img/sec on 40 GPU(s): 730.2 +-192.5
kungfu@relay:~/run-distributed-experiments$

```